### PR TITLE
drop el6 support

### DIFF
--- a/package/redhat/smartdns.spec
+++ b/package/redhat/smartdns.spec
@@ -8,6 +8,7 @@ URL:            https://github.com/pymumu/smartdns
 Source0:        %{name}-%{version}.tar.gz
 
 BuildRequires:  glibc
+BuildRequires:  centos-release >= 7
 BuildRequires:  openssl-devel
 Requires:       glibc
 Requires:       openssl


### PR DESCRIPTION
version of openssl must be 1.0.2 or higher